### PR TITLE
Update to ripple.js

### DIFF
--- a/scripts/ripples.js
+++ b/scripts/ripples.js
@@ -78,7 +78,8 @@ var ripples = {
 
             // Let ripple fade out (with CSS)
             setTimeout(function() {
-                $ripple.remove();
+
+                $('.ripple').remove();
             }, rippleOutTime);
         };
 


### PR DESCRIPTION
Bug: If anything with ripple class is clicked too many times too fast, the ripple color stays, and the element becomes darker

Fix: on rippleOut($ripple) you have a setTimeout which calls $ripple.remove()
-   I changed this line to say $('.ripple').remove()

This removes any ripple class. I am assuming the user is not going to have multiple mouses trying to make multiple thing ripple at once.

Enjoy the change!!

I am also making angular directives for this library
