### PR TITLE
Add margin to navbar-text class to compensate for larger navbar.

### DIFF
--- a/less/navbar.less
+++ b/less/navbar.less
@@ -19,6 +19,8 @@
 
     .navbar-text {
         color: @navbar-color;
+		margin-top: 20px;
+		margin-bottom: 20px;
     }
 
     .navbar-nav {


### PR DESCRIPTION
Changes the `margin-top` and `margin-bottom` of the `.navbar-text` class from 15px to 20px.

Fixes #44.
