### PR TITLE
Do not add the ripple effect to all a elements

### DIFF
--- a/scripts/material.js
+++ b/scripts/material.js
@@ -3,7 +3,7 @@
 $(function (){
 
     if (ripples) {
-        ripples.init(".btn:not(.btn-link), .navbar a, .nav-tabs a, .withripple");
+        ripples.init(".btn:not(.btn-link), .navbar a:not(.withoutripple), .nav-tabs a:not(.withoutripple), .withripple");
     }
 
     var initInputs = function() {


### PR DESCRIPTION
Sometimes we might not want to have some links "rippled" this patch prevents so. Ideally we'd have the possibility of passing our own set of selectors to ripples.init tho
