### PR TITLE
Fix navbar-inverse background hard coded to indigo

### DIFF
--- a/less/_navbar.less
+++ b/less/_navbar.less
@@ -163,7 +163,7 @@
 
     .variations(~"", background-color, @primary);
     &-inverse {
-        background-color: @indigo;
+        background-color: @navbar-inverse-bg;
     }
     &-material-white {
         background-color: #FFF;

--- a/sass/_navbar.scss
+++ b/sass/_navbar.scss
@@ -158,7 +158,7 @@
 }
 
 .navbar-inverse {
-        background-color: $indigo;
+        background-color: $navbar-inverse-bg;
     }
 
 .navbar-white {


### PR DESCRIPTION
Background color of `navbar-inverse` changed from `indigo` to `navbar-inverse-bg` 
