### PR TITLE
Override default icon font path and interpolate sass variable in string.

### DIFF
--- a/sass/_icons-material-design.scss
+++ b/sass/_icons-material-design.scss
@@ -1,10 +1,10 @@
 @font-face {
     font-family: "Material-Design-Icons";
-    src:url("$material-font-path/Material-Design-Icons.eot?-g7cqhn");
-    src:url("$material-font-path/Material-Design-Icons.eot?#iefix-g7cqhn") format("embedded-opentype"),
-        url("$material-font-path/Material-Design-Icons.woff?-g7cqhn") format("woff"),
-        url("$material-font-path/Material-Design-Icons.ttf?-g7cqhn") format("truetype"),
-        url("$material-font-path/Material-Design-Icons.svg?-g7cqhn#Material-Design-Icons") format("svg");
+    src:url("#{$material-font-path}/Material-Design-Icons.eot?-g7cqhn");
+    src:url("#{$material-font-path}/Material-Design-Icons.eot?#iefix-g7cqhn") format("embedded-opentype"),
+        url("#{$material-font-path}/Material-Design-Icons.woff?-g7cqhn") format("woff"),
+        url("#{$material-font-path}/Material-Design-Icons.ttf?-g7cqhn") format("truetype"),
+        url("#{$material-font-path}/Material-Design-Icons.svg?-g7cqhn#Material-Design-Icons") format("svg");
     font-weight: normal;
     font-style: normal;
 }

--- a/sass/_variables.scss
+++ b/sass/_variables.scss
@@ -1,5 +1,5 @@
 // material icons path
-$material-font-path: "../fonts";
+$material-font-path: "../fonts" !default;
 
 // Material colors palette
 $red: #F44336 !default;


### PR DESCRIPTION
Allow changing font path for material design icons font. And interpolate the font face source path properly.
