### PR TITLE
Fixed onChange unexpectedly triggered

### DIFF
--- a/scripts/material.js
+++ b/scripts/material.js
@@ -125,8 +125,8 @@
             (function() {
                 // This part of code will detect autofill when the page is loading (username and password inputs for example)
                 var loading = setInterval(function() {
-                    $("input").each(function() {
-                        if ($(this).val() !== $(this).attr("value")) {
+                    $("input[type!=checkbox]").each(function() {
+                        if ($(this).val() && $(this).val() !== $(this).attr("value")) {
                             $(this).trigger("change");
                         }
                     });


### PR DESCRIPTION
Checking the value for a checkbox input is not wisely, prefer checking the "checked" attribute, we also need to verify if there is a value in the input because default value (for example a text input) is "" and $(this).attr("value") returns undefined.

Fixes #205 
