### PR TITLE
Allow -font-path to be overridden.

### DIFF
--- a/sass/_variables.scss
+++ b/sass/_variables.scss
@@ -1,5 +1,5 @@
 // material icons path
-$material-font-path: "../fonts";
+$material-font-path: "../fonts" !default;
 
 // Material colors palette
 $red: #F44336 !default;


### PR DESCRIPTION
Allowing `$material-font-path` to be an overridden variable.
