### PR TITLE
Corrects a header id in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -529,7 +529,7 @@
                 <div class="row">
                     <div class="col-lg-12">
                         <div class="page-header">
-                            <h1 id="type">Icons</h1>
+                            <h1 id="icons">Icons</h1>
                             <p>Material Design for Bootstrap includes 740 original Material Design icons!<br>
                                 These icons come directly from the <a href="https://github.com/google/material-design-icons">Google Material Design Icons</a> repository.<br>
                                 We provide them as an iconic font easy to use.


### PR DESCRIPTION
Corrects the icons header id from "type" (used also in typography) to "icons".

Tiny fix, which allows you to link to http://fezvrasta.github.io/bootstrap-material-design/#icons . This url not working is how I noticed the error.
