### PR TITLE
Make the name in bower.json the same as the registered name

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "Material Design for Bootstrap",
+  "name": "bootstrap-material-design",
   "version": "0.2.0",
   "homepage": "http://fezvrasta.github.io/bootstrap-material-design",
   "authors": [


### PR DESCRIPTION
Needed to comply to http://bower.io/docs/creating-packages/#register and more specific to https://github.com/bower/bower.json-spec#name
