### PR TITLE
rippleOut on click and touchend

### DIFF
--- a/scripts/ripples.js
+++ b/scripts/ripples.js
@@ -148,7 +148,7 @@
       }, 500);
 
       // On mouseup or on mouseleave, set the mousedown flag to "off" and try to destroy the ripple
-      element.on("mouseup mouseleave", function() {
+      element.on("mouseup mouseleave click touchend", function() {
         ripple.data("mousedown", "off");
         // If the transition "on" is finished then we can destroy the ripple with transition "out"
         if (ripple.data("animating") == "off") {

--- a/scripts/ripples.js
+++ b/scripts/ripples.js
@@ -148,7 +148,7 @@
       }, 500);
 
       // On mouseup or on mouseleave, set the mousedown flag to "off" and try to destroy the ripple
-      element.on("mouseup mouseleave click touchend", function() {
+      element.on("mouseup mouseleave touchend", function() {
         ripple.data("mousedown", "off");
         // If the transition "on" is finished then we can destroy the ripple with transition "out"
         if (ripple.data("animating") == "off") {


### PR DESCRIPTION
On iOS, ripple is not faded out if you hold and swipe your finger.
It should handle `touchend` event to trigger rippleOut.
The `click` event might be even necessary to handle for other possibility of the problem.
