### PR TITLE
Meteor integration and README improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ Thumbs.db
 /node_modules/
 .grunt/
 /bower_components/
+.build*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,14 @@
 language: node_js
-node_js:
-  - "0.10"
+
+node_js: "0.10"
+
 before_script:
-  - "npm install -g grunt-cli"
+  - npm install -g grunt-cli
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
-script: "grunt cibuild"
+  # Install meteor
+  - curl https://install.meteor.com | /bin/sh
+  # Install spacejam, Meteor's CI helper
+  - npm install -g spacejam
+
+script: grunt cibuild

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -204,7 +204,30 @@ module.exports = function(grunt) {
           "**/*.{png,jpg,jpeg,gif,webp,svg}"
         ]
       }
+    },
+    exec: {
+      "meteor-init": {
+        command: [
+          // Make sure Meteor is installed, per https://meteor.com/install.
+          // The curl'ed script is safe; takes 2 minutes to read source & check.
+          "type meteor >/dev/null 2>&1 || { curl https://install.meteor.com/ | sh; }",
+          // Meteor expects package.js to be in the root directory of
+          // the checkout, so copy it there temporarily
+          "cp meteor/package.js ."
+        ].join(";")
+      },
+      "meteor-cleanup": {
+        // remove build files and package.js
+        command: "rm -rf .build.* versions.json package.js"
+      },
+      "meteor-test": {
+        command: "node_modules/.bin/spacejam --mongo-url mongodb:// test-packages ./"
+      },
+      "meteor-publish": {
+        command: "meteor publish"
+      }
     }
+
   });
 
   grunt.registerTask("default", ["material", "ripples"]);
@@ -265,5 +288,11 @@ module.exports = function(grunt) {
     ]);
   });
 
-  grunt.registerTask("cibuild",["newer:jshint", "jasmine:scripts"]);
+  // Meteor tasks
+  grunt.registerTask("meteor-test", ["exec:meteor-init", "exec:meteor-test", "exec:meteor-cleanup"]);
+  grunt.registerTask("meteor-publish", ["exec:meteor-init", "exec:meteor-publish", "exec:meteor-cleanup"]);
+  grunt.registerTask("meteor", ["exec:meteor-init", "exec:meteor-test", "exec:meteor-publish", "exec:meteor-cleanup"]);
+
+  grunt.registerTask("cibuild", ["newer:jshint", "jasmine:scripts", "meteor-test"]);
+
 };

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![banner](demo/imgs/banner.jpg)](#)
 
 This Bootstrap theme is an easy way to use the new [Material Design guidelines by Google](http://www.google.com/design/spec/material-design/introduction.html) in your Bootstrap 3 based application.
-Just include the theme, after the Bootstrap CSS and include the javascript at the end of your document (Just before the end of the `<body>` tag), and everything will be converted to Material Design (paper) style.
+Just include the theme, after the Bootstrap CSS and include the JavaScript at the end of your document (just before the `</body>` tag), and everything will be converted to Material Design (Paper) style.
 
 **NOTE**: This theme is in early development and is not ready for production.
 
@@ -13,6 +13,7 @@ Check out [the demo at this link](http://fezvrasta.github.io/bootstrap-material-
 ## How to install
 
     BOWER:       bower install bootstrap-material-design --save
+    Meteor:      meteor add fezvrasta:bootstrap-material-design
 
 ## Use our CDN
 
@@ -20,8 +21,8 @@ You can find the CDN of this library at [CDNJS.com](https://cdnjs.com/libraries/
 
 ### LESS & SASS
 
-Currently only LESS is maintained, the SASS version has not a maintainer anymore (#256).
-The SASS files are in the source just because if someone wants to update the source he can use these files as base.
+Currently only LESS is maintained. The SASS version no longer has a maintainer (#256).
+The SASS files are in the source just in case someone wants to update the source from SASS and use these files as a base.
 
 ## Getting started
 
@@ -30,14 +31,14 @@ You need to copy the `dist/` folder to the root of your project, ensuring that a
 
 ## Development
 
-We are using grunt to automate the workflow and build process. Ensure you have nodejs installed and grunt-cli installed globally.
+We are using Grunt to automate the workflow and build process. Ensure you have nodejs installed and grunt-cli installed globally.
 After cloning the repo, run `npm install` to ensure you have all dev dependencies.
 
 Run the `grunt build` command to run the tests and compile the less/sass. See [Gruntfile.js](Gruntfile.js) for details on targets.
 
-Run the `grunt test` command for browser based jasmine unit tests.
+Run the `grunt test` command for browser-based Jasmine unit tests.
 
-Run the `grunt serve` command to build and fire up a http server with live-reload and a watch for development purposes.
+Run the `grunt serve` command to build and fire up an http server with live-reload and a watch for development purposes.
 
 ## Todo
 
@@ -47,25 +48,25 @@ Run the `grunt serve` command to build and fire up a http server with live-reloa
 - [Icon button](http://www.polymer-project.org/components/paper-icon-button/demo.html)
 - [Tabs](http://www.polymer-project.org/components/paper-tabs/demo.html)
 
-I'll try to write every component without the need of Javascript but just CSS, and use JS only if strictly needed.
-More "todo" things can be found in the ISSUES of this repository.
+I'll try to write every component without the need of JavaScript but just CSS, and use JS only if strictly needed.
+More "todo" items can be found in the ISSUES of this repository.
 
-# Support me
+## Support me
 
 If you like this project you may support me by donating something on Gittip, starring this repository or reporting bugs and ideas in the issue section.
 
 [![gittip](demo/imgs/gittip-button.jpg)](https://www.gratipay.com/FezVrasta/)
 [![issues](demo/imgs/issues-button.jpg)](https://github.com/FezVrasta/bootstrap-material-design/issues)
 
-# Contribute
+## Contribute
 
 Please see the [CONTRIBUTING.md](CONTRIBUTING.md) file.
 
-# Documentation
+## Documentation
 
 Material Design for Bootstrap provides some additional stuff to get the best from Material Design.
 
-### Variations:
+### Variations
 
 There are 17 additional color variations (in addition to the classic 4 variations) for buttons, inputs, checkboxes, radios, alerts, navbars, tabs, labels, paginations, progress bars and more.
 They can be used by adding the class suffix `-material-color` to the desired element and replacing `color` with the desired one.
@@ -78,12 +79,12 @@ These colors are taken from the Material Design color palette and are reported b
 
 ![palette](demo/imgs/palette.jpg)
 
-### Buttons:
+### Buttons
 
 Add `.btn-flat` to a button to make it flat, without shadows.
 Add `.btn-raised` to a button to add a permanent shadow to it.
 
-### Inputs:
+### Inputs
 
 Add `.floating-label` to an input field with a `placeholder` to transform the placeholder in a floating label.
 
@@ -98,7 +99,7 @@ Remember to use the proper HTML markup to get radio and checkboxes styled correc
         </label>
     </div>
 
-### Icons:
+### Icons
 
 Material Design for Bootstrap includes 490 original Material Design icons!
 These icons are extracted from the original Google sources and are licensed under the BSD license.
@@ -110,11 +111,11 @@ The syntax to add a Material icon is:
 
      <i class="icon icon-material-favorite"></i>
 
-# Material.js
+## Material.js
 
 `Material.js` is a jQuery plugin that add some magic to your markup and allows Material Design for Bootstrap to style some elements like inputs, checkboxes, radios etc.
 
-### Functions:
+### Functions
 
 This plugin exposes some functions, them are:
 
@@ -124,13 +125,13 @@ This plugin exposes some functions, them are:
 `$.material.checkbox():` will enable the MD style to the checkboxes (remember to follow the markup guidelines explained in the Inputs chapter.
 `$.material.radio():` will enable the MD style to the checkboxes (remember to follow the markup guidelines explained in the Inputs chapter.
 
-### Apply Material.js only to specific elements:
+### Apply Material.js only to specific elements
 
-Every function expects an optional value that will be used as selector for the function, for example
-  `$.material.ripples("#selector, #foobar")` will apply Ripples.js only to `#selector` and `#foobar`.
+Every function expects an optional value that will be used as a selector for the function; for example,
+`$.material.ripples("#selector, #foobar")` will apply Ripples.js only to `#selector` and `#foobar`.
 The functions that allows an optional selector are `$.material.ripples`, `$.material.input`, `$.material.checkbox` and `$.material.radio`.
 
-You can even override the default values using the `$.material.options` function, the default values are:
+You can even override the default values using the `$.material.options` function. The default values are:
 
     $.material.options = {
         "withRipples": ".btn:not(.btn-link), .card-image, .navbar a:not(.withoutripple), .nav-tabs a:not(.withoutripple), .withripple",
@@ -141,31 +142,31 @@ You can even override the default values using the `$.material.options` function
 
 ### Arrive.js support
 
-If you need to dynamically add elements to your DOM then you may need to include `Arrive.js` before `Material.js`, this will automatically apply `Material.js` to every new element added by you using JS.
+If you need to dynamically add elements to your DOM then you may need to include `Arrive.js` before `Material.js`. This will automatically apply `Material.js` to every new element added via JavaScript.
 
-# Plugins
+## Plugins
 
 Material Design for Bootstrap comes with styling support for various external scripts:
 
 ### SnackbarJS
 
-Create snackbars and toasts with [SnackbarJS plugin](https://github.com/FezVrasta/snackbarjs). The default toast style is the squared one (snackbar style). If you like to use the rounded style (toast style), please add the `toast` class to the `style` option of SnackbarJS.
+Create snackbars and toasts with the [SnackbarJS plugin](https://github.com/FezVrasta/snackbarjs). The default toast style is the squared one (snackbar style). If you like to use the rounded style (toast style), please add the `toast` class to the `style` option of SnackbarJS.
 
 ### RipplesJS
 
-This is part of Material Design for Bootstrap project and is a plain Javascript script which creates the ripple effect on click of the defined elements.
+This is part of the Material Design for Bootstrap project and is a plain JavaScript script which creates the ripple effect when clicking on the specified elements.
 At the moment RipplesJS does not have its own repository but it will probably have one in the future.
 
 ### noUiSlider
 
 Make cross-browser sliders and get them styled with Material Design thanks to the support provided by this theme.
-Read more about [noUiSlider here](http://refreshless.com/nouislider/)
+Read more about [noUiSlider here](http://refreshless.com/nouislider/).
 
 ### Selectize.js
 
-Transform select and multi select inputs in advanced text inputs. Material Design for BS provides a full replacement of the plugin's CSS, so don't include it.
-Read more about [selectize.js](http://brianreavis.github.io/selectize.js/)
+Transform select and multi-select inputs into advanced text inputs. Material Design for BS provides a full replacement of the plugin's CSS, so don't include it.
+Read more about [selectize.js](http://brianreavis.github.io/selectize.js/).
 
-# Compatibility
+## Compatibility
 
-Currently Material Design for Bootstrap supports Google Chrome (tested v37+), Mozilla Firefox (tested 30+), and Internet Explorer (tested 11+). Mobile browsers are not currently tested but it may work.
+Currently, Material Design for Bootstrap supports Google Chrome (tested v37+), Mozilla Firefox (tested 30+), and Internet Explorer (tested 11+). Mobile browsers are not currently tested but they may work.

--- a/meteor/README.md
+++ b/meteor/README.md
@@ -1,0 +1,52 @@
+[![Build Status](https://travis-ci.org/MeteorPackaging/hammer.js.svg?branch=master)](https://travis-ci.org/MeteorPackaging/hammer.js)
+
+Packaging [FezVrasta's Bootstrap Material Design](https://github.com/FezVrasta/bootstrap-material-design)
+for [Meteor.js](http://meteor.com).
+
+# Usage
+
+Just run
+
+
+```sh
+meteor add meteorpackaging:bootstrap-material-design
+```
+
+and your Bootstrap CSS will look like Google's Material Design (Polymer Paper).
+
+
+# Dependencies
+
+* [twbs:bootstrap](https://atmospherejs.com/twbs/bootstrap) (the official community integration package for Bootstrap 3)
+* jquery
+
+
+# Meteor
+
+If you're new to Meteor, here's what the excitement is all about -
+[watch the first two minutes](https://www.youtube.com/watch?v=fsi0aJ9yr2o); you'll be hooked by 1:28.
+
+That screencast is from 2012. In the meantime, Meteor has become a mature JavaScript-everywhere web
+development framework. Read more at [Why Meteor](http://www.meteorpedia.com/read/Why_Meteor).
+
+
+# Issues
+
+If you encounter an issue while using this package, please CC @dandv when you file it in this repo.
+
+
+# DONE
+
+* Icons font loading test: EOT, SVG, TTF, WOFF
+* Ripples test
+
+
+# TODO
+
+* Depend on a version of twbs:bootstrap without the Glyphicons font, to avoid loading those obsoleted icons
+
+
+# Acknowledgements
+
+* [Yuri Dybskiy / html5cat](https://github.com/html5cat) for the first wrapper of this package
+* [Dan Dascalescu / dandv](https://github.com/dandv) for this direct integration

--- a/meteor/package.js
+++ b/meteor/package.js
@@ -1,0 +1,38 @@
+// package metadata file for Meteor.js
+'use strict';
+
+var packageName = 'fezvrasta:bootstrap-material-design';  // https://atmospherejs.com/fezvrasta/bootstrap-material-design
+var where = 'client';  // where to install: 'client' or 'server'. For both, pass nothing.
+
+var packageJson = JSON.parse(Npm.require("fs").readFileSync('package.json'));
+
+Package.describe({
+  name: packageName,
+  summary: 'FezVrasta\'s Bootstrap theme implementing Google\'s Material (Paper) Design',
+  version: packageJson.version,
+  git: 'https://github.com/fezvrasta/bootstrap-material-design.git'
+});
+
+Package.onUse(function (api) {
+  api.versionsFrom(['METEOR@0.9.0', 'METEOR@1.0']);
+  api.use('twbs:bootstrap@3.3.1');
+  api.use('jquery');
+  api.addFiles([
+    // we bundle all font files, but the client will request only one of them via the CSS @font-face rule
+    'dist/fonts/Material-Design-Icons.eot',  // IE8 or older
+    'dist/fonts/Material-Design-Icons.svg',  // SVG fallback for iOS < 5 - http://caniuse.com/#feat=svg-fonts, http://stackoverflow.com/a/11002874/126903
+    'dist/fonts/Material-Design-Icons.ttf',  // Android Browers 4.1, 4.3 - http://caniuse.com/#feat=ttf
+    'dist/fonts/Material-Design-Icons.woff', // Supported by all modern browsers
+    'dist/css/material-wfont.css',           // includes @font-face rules to load the Roboto font
+    'dist/css/ripples.css',
+    'dist/js/material.js',
+    'dist/js/ripples.js'
+  ], where);
+});
+
+Package.onTest(function (api) {
+  api.use(packageName, where);
+  api.use(['tinytest', 'http'], where);
+
+  api.addFiles('meteor/test.js', where);
+});

--- a/meteor/test.js
+++ b/meteor/test.js
@@ -1,0 +1,103 @@
+'use strict';
+
+var packageName;  // there seems to be no official way of finding out the name of the very package we're testing - http://stackoverflow.com/questions/27180709/in-a-tinytest-test-file-how-do-i-get-the-name-of-the-package
+
+// Check that the font files are downloadable. Meteor places assets at /packages/<packageName>/.
+// Only 'woff' for now, but 'woff2' may become available - https://github.com/FortAwesome/Font-Awesome/pull/5062#discussion_r20936453
+['eot', 'svg', 'ttf', 'woff'].forEach(function (font) {
+  Tinytest.addAsync(font + ' fonts are shipped', function (test, done) {
+
+    // curiously enough, the 'local-test:...' package isn't loaded into Package before calling Tinytest, so we can't do this determination outside this loop
+    if (!packageName)
+      Object.keys(Package).forEach(function(p) {
+        if (p.search(/local-test/) > -1)
+          packageName = p.replace('local-test:', '');  // we should stop the loop, but forEach can't do that
+      })
+
+    if (!packageName) {
+      test.exception({message: 'Package not quite loaded... go figure'});
+      return
+    }
+
+    var packagePath = packageName.replace(':', '_')  // e.g. meteorpackaging_bootstrap-material-design
+
+    HTTP.get(
+      '/packages/' + packagePath + '/dist/fonts/Material-Design-Icons.' + font,
+      {
+         headers: {
+           'Cache-Control': 'no-cache'  // because Meteor has cached fonts even after they were removed from package.js (!) - https://github.com/meteor/meteor/issues/3196
+         }
+      },
+      function callback(error, result) {
+        if (error) {
+          test.fail({message: 'Font failed to load'});
+        } else {
+          // if the file is 404, Meteor will redirect to / and return the Meteor.js boilerplate
+          test.isTrue(result.content.length > 100000, font + ' font could not be downloaded');
+        }
+
+        done();
+      }
+    );
+  });
+})
+
+var plugins = ['affix', 'alert', 'button', 'carousel', 'collapse', 'dropdown', 'modal', 'popover', 'scrollspy', 'tab', 'tooltip'];
+
+// test plugins
+plugins.forEach(function (plugin) {
+  Tinytest.add('Plugin - ' + plugin, function (test) {
+    test.instanceOf($(document.body)[plugin], Function, 'instantiated correctly');
+  });
+});
+
+// visual check
+plugins.forEach(function (plugin) {
+
+  Tinytest.addAsync('Visual check - ' + plugin, function (test, done) {
+    var bootstrapDropZone = document.createElement('div');
+    document.body.appendChild(bootstrapDropZone);
+
+
+    HTTP.get('http://rawgit.com/twbs/bootstrap/master/js/tests/visual/' + plugin + '.html', function callback(error, result) {
+      if (error) {
+        test.fail('Error getting the test file. Do we have an Internet connection to rawgit.com?');
+      } else {
+        // [^] matches across newlines. Stay within the container div, or else the fragment will attempt to load resources on its own.
+        bootstrapDropZone.innerHTML = result.content.match(/<div[^]+<\/div>/);
+        test.ok({message: 'Test passed if the display looks OK *and* clicking dropdowns/popovers/tooltips works.'});
+      }
+
+      done();
+    });
+
+  });
+
+});
+
+
+Tinytest.addAsync('Visual check - Material Design', function (test, done) {
+  var bootstrapDropZone = document.createElement('div');
+  document.body.appendChild(bootstrapDropZone);
+
+  HTTP.get('http://rawgit.com/FezVrasta/bootstrap-material-design/master/bootstrap-elements.html', function callback(error, result) {
+    if (error) {
+      test.fail('Error getting the FezVrasta test file. Do we have an Internet connection to rawgit.com?');
+    } else {
+      // [^] matches across newlines. Stay within the container div, or else the fragment will attempt to load resources on its own.
+      bootstrapDropZone.innerHTML = result.content.match(/<meta name="viewport"[^]+<script src=/);
+      test.ok({message: 'Test passed if the display looks OK *and* clicking dropdowns/popovers/tooltips works.'});
+      // only does anything after loading the 'dropdown' plugin test
+      $('[data-toggle="dropdown"]').dropdown();
+      // only does anything after loading the 'popover' plugin test
+      $('[data-toggle="popover"]').popover();
+      // only does anything after loading the 'tooltip' plugin test
+      $('[data-toggle="tooltip"]').tooltip();
+      // don't initialize the modals because that messes up the Tinytest runner HTML
+      $.material.init();
+    }
+
+    done();
+  });
+
+});

--- a/package.json
+++ b/package.json
@@ -29,8 +29,10 @@
     "grunt-contrib-uglify": "^0.6.0",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-csswring": "^1.1.0",
+    "grunt-exec": "^0.4.6",
     "grunt-newer": "^0.7.0",
     "jshint-stylish": "^1.0.0",
-    "load-grunt-tasks": "^0.6.0"
+    "load-grunt-tasks": "^0.6.0",
+    "spacejam": "^1.1.1"
   }
 }


### PR DESCRIPTION
Hi Federico,

As you might know, the [Meteor](http://meteor.com) community loves Bootstrap and your Material Design theme. We had [a wrapper package](https://github.com/html5cat/bootstrap-material-design/) that @html5cat asked me to help with, so I'm submitting a PR that integrates Meteor packaging directly, along with Travis and Grunt tests.

This PR will let you directly publish updated versions of the library as they become available. All you have to do is create an account at https://meteor.com/ (click _SIGN IN_, then _Create account_). After you've done that, please let me know the name of the account, and I'll add you as a maintainer. (`fezvrasta` is taken because it's the namespace of the organization owning the package).

I've already published the current version of the package on [Atmosphere](https://atmospherejs.com/hammer/hammer) (Meteor's package directory). When you release new versions, you can publish them to Atmosphere with `grunt meteor`.

Thanks & best regards,
Dan & the [Meteor integrations team](https://github.com/raix/Meteor-community-discussions/issues/14)
