### PR TITLE
Class Order Independent Button Hovers

### DIFF
--- a/less/_buttons.less
+++ b/less/_buttons.less
@@ -70,13 +70,13 @@
 }
 
 // This is needed to style buttons which has not a variation suffix (they must be stiled as btn-default)
-.btn-link, .btn:not([class^="btn btn-"]), .btn-default {
+.btn-link, .btn:not([class*="btn-"]), .btn-default {
   color: @lightbg-text;
   &:hover {
     color: @lightbg-text;
   }
 }
-.btn:not([class^="btn btn-"]), .btn-default, .btn-flat:not(.btn-link) {
+.btn:not([class*="btn-"]), .btn-default, .btn-flat:not(.btn-link) {
   &:hover, &.active {
     background-color: rgba(255,255,255,0.5);
   }


### PR DESCRIPTION
Allows .btn\* classes to be specified in any order and still receive proper hover state colors.

Addresses one of the issues in #269 .
