### PR TITLE
Don't set floating label on leave

### DIFF
--- a/scripts/material.js
+++ b/scripts/material.js
@@ -14,7 +14,7 @@
     if (typeof evt.which == "undefined") {
       return true;
     } else if (typeof evt.which == "number" && evt.which > 0) {
-      return !evt.ctrlKey && !evt.metaKey && !evt.altKey && evt.which != 8;
+      return !evt.ctrlKey && !evt.metaKey && !evt.altKey && evt.which != 8 && evt.which != 9;
     }
     return false;
   }


### PR DESCRIPTION
Navigation over empty fields using Tab should not bounce the labels
