### PR TITLE
Fixed alert text colors

### DIFF
--- a/less/_alerts.less
+++ b/less/_alerts.less
@@ -1,16 +1,22 @@
 .alert {
     border: 0px;
     border-radius: 0;
-    a, .alert-link {
-        color: #FFFFFF;
-    }
-    .variations(~"", background-color, #FFFFFF);
+
+    .generic-variations(~"", @darkbg-text, {
+        background-color: @material-color; color: @text-color;
+        a, .alert-link {
+            color: @text-color;
+        }
+    });
+
     &-info, &-danger, &-warning, &-success {
-        color: #FFFFFF;
+        color: @darkbg-text;
     }
     &-default {
         a, .alert-link {
-            color: #000000;
+            color: @lightbg-text;
         }
     }
 }
+
+

--- a/less/_navbar.less
+++ b/less/_navbar.less
@@ -174,11 +174,17 @@
   }
 
   @media (max-width: 1199px) {
+    .navbar-text {
+      color: inherit;
+      margin-top: 15px;
+      margin-bottom: 15px;
+    }
 
     .navbar-brand {
       height: 50px;
       padding: 10px 15px;
     }
+
     .navbar-form {
       margin-top: 10px;
     }


### PR DESCRIPTION
The textcolors of an alert are always black when material styles are used. For example; alert alert-primary has a black text color. 
Only alert-info, alert-danger, alert-warning, alert-success have correct text-colors.
