### PR TITLE
Don't cancel event chain on mousedown

### DIFF
--- a/scripts/ripples.js
+++ b/scripts/ripples.js
@@ -51,7 +51,7 @@
        * Verify if the user is just touching on a device and return if so
        */
       if(self.isTouch() && event.type === "mousedown") {
-        return false;
+        return;
       }
 
 


### PR DESCRIPTION
In mobile devices, after a `touchstart`a `moudedown` is fired and at the end of the chain a `focus` and a `click` event.

I have a view with two form fields and a button, using knockout. In the original code the event chain is cancelled and the button is not yet focused so the last used form control is not yet blurred so the value is not passed to the model. This makes the validation to fail because the form is submitted before the model is updated.

Many MVVM libraries update the models on blur, so this `return false` is causing problems. As well, there might be a good reason to have this `false` but I can't see it.
