### PR TITLE
Fix Sass material font path variable

### DIFF
--- a/sass/_icons-material-design.scss
+++ b/sass/_icons-material-design.scss
@@ -1,10 +1,10 @@
 @font-face {
     font-family: 'Material-Design-Icons';
-    src:url('#{material-font-path}/Material-Design-Icons.eot?3ocs8m');
-    src:url('#{material-font-path}/Material-Design-Icons.eot?#iefix3ocs8m') format('embedded-opentype'),
-        url('#{material-font-path}/Material-Design-Icons.woff?3ocs8m') format('woff'),
-        url('#{material-font-path}/Material-Design-Icons.ttf?3ocs8m') format('truetype'),
-        url('#{material-font-path}/Material-Design-Icons.svg?3ocs8m#Material-Design-Icons') format('svg');
+    src:url('#{$material-font-path}/Material-Design-Icons.eot?3ocs8m');
+    src:url('#{$material-font-path}/Material-Design-Icons.eot?#iefix3ocs8m') format('embedded-opentype'),
+        url('#{$material-font-path}/Material-Design-Icons.woff?3ocs8m') format('woff'),
+        url('#{$material-font-path}/Material-Design-Icons.ttf?3ocs8m') format('truetype'),
+        url('#{$material-font-path}/Material-Design-Icons.svg?3ocs8m#Material-Design-Icons') format('svg');
     font-weight: normal;
     font-style: normal;
 }


### PR DESCRIPTION
The font path was missing a $, so in the Sass output it simply says 'material-font-path' as a string. By adding the $ it respects the variable.
