### PR TITLE
Remove conflicting font declaration from .icon-preview span

### DIFF
--- a/bootstrap-elements.html
+++ b/bootstrap-elements.html
@@ -34,7 +34,6 @@
                 color: #EEE;
                 padding: 5px 8px;
                 font-size: 15px;
-                font-family: Roboto;
                 border-radius: 2px;
                 z-index: 10;
             }


### PR DESCRIPTION
Fix's This caused by declaring wrong font
![font](https://cloud.githubusercontent.com/assets/3852827/7200312/72df93d0-e519-11e4-8cba-170a136f07d6.PNG)
