### PR TITLE
Fix small icons on chrome

### DIFF
--- a/less/_buttons.less
+++ b/less/_buttons.less
@@ -86,12 +86,13 @@
     &.btn-fab-mini {
       width: 40px;
       height: 40px;
-      padding: 13px;
+      padding: 13px 0;
       font-size: 15px;
     }
     i {
       position: relative;
       top: -5px;
+      margin: 0 auto;
     }
   }
 }


### PR DESCRIPTION
This fixes icons for chrome, and puts the icon content centred.

Before:
![Before](http://i.imgur.com/Rbg0nb1.png)

After:
![After](http://i.imgur.com/Fz33xLg.png)
