### PR TITLE
Replace hard-coded font path in roboto.less

### DIFF
--- a/less/roboto.less
+++ b/less/roboto.less
@@ -1,3 +1,6 @@
+@import "_variables.less";
+@import "_colors.less";
+
 @font-face {
   font-family: 'RobotoDraft';
   font-style: normal;
@@ -6,8 +9,8 @@
   src: local('RobotoDraft'),
        local('RobotoDraft-Regular'),
        local('Roboto-Regular'),
-       url(../fonts/RobotoDraftRegular.woff2) format('woff2'),
-       url(../fonts/RobotoDraftRegular.woff) format('woff');
+       url('@{material-font-path}/RobotoDraftRegular.woff2') format('woff2'),
+       url('@{material-font-path}/RobotoDraftRegular.woff') format('woff');
 }
 
 @font-face {
@@ -18,8 +21,8 @@
   src: local('RobotoDraft Medium'),
        local('RobotoDraft-Medium'),
        local('Roboto-Medium'),
-       url(../fonts/RobotoDraftMedium.woff2) format('woff2'),
-       url(../fonts/RobotoDraftMedium.woff) format('woff');
+       url('@{material-font-path}/RobotoDraftMedium.woff2') format('woff2'),
+       url('@{material-font-path}/RobotoDraftMedium.woff') format('woff');
 }
 
 @font-face {
@@ -30,8 +33,8 @@
   src: local('RobotoDraft Bold'),
        local('RobotoDraft-Bold'),
        local('Roboto-Bold'),
-       url(../fonts/RobotoDraftBold.woff2) format('woff2'),
-       url(../fonts/RobotoDraftBold.woff) format('woff');
+       url('@{material-font-path}/RobotoDraftBold.woff2') format('woff2'),
+       url('@{material-font-path}/RobotoDraftBold.woff') format('woff');
 }
 
 @font-face {
@@ -42,6 +45,6 @@
   src: local('RobotoDraft Italic'),
        local('RobotoDraft-Italic'),
        local('Roboto-Italic'),
-       url(../fonts/RobotoDraftItalic.woff2) format('woff2'),
-       url(../fonts/RobotoDraftItalic.woff) format('woff');
+       url('@{material-font-path}/RobotoDraftItalic.woff2') format('woff2'),
+       url('@{material-font-path}/RobotoDraftItalic.woff') format('woff');
 }


### PR DESCRIPTION
The path for fonts were hard-coded into the `roboto.less` file. I imported the required `_variable.less` and `_colors.less` files into `roboto.less`, so that the `@{material-font-path}` variable containing the fonts path could be reached.

fixes #697
