### PR TITLE
bootstrap-sass dependency

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -6,7 +6,7 @@ module.exports = function (grunt) {
   var path = require('path');
   var configBridge = grunt.file.readJSON('./grunt/configBridge.json', {encoding: 'utf8'});
   var generateIconsData = require('./grunt/bmd-icons-data-generator.js');
-  
+
   Object.keys(configBridge.paths).forEach(function (key) {
     configBridge.paths[key].forEach(function (val, i, arr) {
       arr[i] = path.join('./docs/assets', val);
@@ -228,6 +228,9 @@ module.exports = function (grunt) {
     // Test compile sass
     sass: {
       compile: {
+        options:{
+          loadPath: "bower_components/bootstrap-sass/assets/stylesheets",
+        },
         files: [{
           expand: true,
           cwd: "sass",

--- a/sass/_import-bs-sass.scss
+++ b/sass/_import-bs-sass.scss
@@ -1,2 +1,2 @@
-@import "../bower_components/bootstrap-sass/assets/stylesheets/bootstrap/variables";
+@import "bootstrap/variables";
 //@import "../bower_components/bootstrap-sass/assets/stylesheets/bootstrap/mixins";


### PR DESCRIPTION
The sass version imports an hard-coded version of bootstrap-sass:
`@import "../bower_components/bootstrap-sass/assets/stylesheets/bootstrap/variables"`

This works well only when bootstrap-material-design is not consumed as a bower component itself.
The solution to this will be to load the bootstrap-sass location in the loadPath for sass which would be searched upon import.

I've changed the grunt file so the tests would run.
