### PR TITLE
Rework import of bootstrap variables to prevent error when importing in less after installing with bower

### DIFF
--- a/less/_import-bs-less.less
+++ b/less/_import-bs-less.less
@@ -1,2 +1,3 @@
-@import "../bower_components/bootstrap/less/variables.less";
+@import (optional) "../../bootstrap/less/variables.less";
+@import (optional) "../bower_components/bootstrap/less/variables.less";
 //@import "../bower_components/bootstrap/less/mixins.less";


### PR DESCRIPTION
Make original import optional to prevent error when importing the design
in less after install with bower.
Add additional optional import pointing to bootstrap when
bootstrap-material-design was installed with bower.

Fixes #814 
