### PR TITLE
Fixed Meteor tests failing because of jQuery conflict. Related #769

### DIFF
--- a/meteor/test.js
+++ b/meteor/test.js
@@ -1,4 +1,5 @@
 'use strict';
+$ =jQuery.noConflict();
 
 //var packageName;  // there seems to be no official way of finding out the name of the very package we're testing - http://stackoverflow.com/questions/27180709/in-a-tinytest-test-file-how-do-i-get-the-name-of-the-package
 //


### PR DESCRIPTION
By adding `$ =jQuery.noConflict();` at the beginning of the `test.js` file for the Meteor package, I was able to fix the issue of the meteor grunt tasks failing.
