### PR TITLE
Make markup changes idempotent

### DIFF
--- a/bootstrap-elements.html
+++ b/bootstrap-elements.html
@@ -1815,7 +1815,7 @@
         <h2>Modals</h2>
 
         <div class="bs-component">
-          <div class="modal">
+          <div class="modal" tabindex="-1">
             <div class="modal-dialog">
               <div class="modal-content">
                 <div class="modal-header">

--- a/index.html
+++ b/index.html
@@ -89,7 +89,7 @@
             <form action="https://www.paypal.com/cgi-bin/webscr" id="paypal" method="post" target="_blank" style="display: inline-block;">
               <input type="hidden" name="cmd" value="_s-xclick">
 
-              <div class="btn btn-primary">
+              <div>
                 <select name="hosted_button_id" title="I can't accept less than 5 euro due to accounting troubles">
                   <option value="DAAK965W2DKYE">&euro; 5,00</option>
                   <option value="28PH77JK5QWFE">&euro; 10,00</option>

--- a/scripts/material.js
+++ b/scripts/material.js
@@ -83,9 +83,9 @@
       var $input = $((selector) ? selector : this.options.checkboxElements)
         .filter(":notmdproc")
         .data("mdproc", true);
-      if ($input.siblings(".checkbox-material").length == 0)
+      if ($input.siblings(".checkbox-material").length === 0) {
         $input.after("<span class='checkbox-material'><span class='check'></span></span>");
-
+      }
       _toggleTypeFocus($input);
     },
     "togglebutton": function (selector) {
@@ -93,9 +93,9 @@
       var $input = $((selector) ? selector : this.options.togglebuttonElements)
         .filter(":notmdproc")
         .data("mdproc", true);
-      if ($input.siblings(".toggle").length == 0)
+      if ($input.siblings(".toggle").length === 0) {
         $input.after("<span class='toggle'></span>");
-
+      }
       _toggleTypeFocus($input);
     },
     "radio": function (selector) {
@@ -103,9 +103,9 @@
       var $input = $((selector) ? selector : this.options.radioElements)
         .filter(":notmdproc")
         .data("mdproc", true);
-      if ($input.siblings(".circle").length == 0)
+      if ($input.siblings(".circle").length === 0) {
         $input.after("<span class='circle'></span><span class='check'></span>");
-
+      }
       _toggleTypeFocus($input);
     },
     "input": function (selector) {
@@ -159,9 +159,9 @@
           }
 
           // Add at the end of the form-group
-          if ($formGroup.siblings(".material-input").length == 0)
+          if ($formGroup.siblings(".material-input").length === 0) {
             $formGroup.append("<span class='material-input'></span>");
-
+          }
           // Support for file input
           if ($formGroup.find("input[type=file]").length > 0) {
             $formGroup.addClass("is-fileinput");

--- a/scripts/material.js
+++ b/scripts/material.js
@@ -82,8 +82,9 @@
       // Add fake-checkbox to material checkboxes
       var $input = $((selector) ? selector : this.options.checkboxElements)
         .filter(":notmdproc")
-        .data("mdproc", true)
-        .after("<span class='checkbox-material'><span class='check'></span></span>");
+        .data("mdproc", true);
+      if ($input.siblings(".checkbox-material").length == 0)
+        $input.after("<span class='checkbox-material'><span class='check'></span></span>");
 
       _toggleTypeFocus($input);
     },
@@ -91,8 +92,9 @@
       // Add fake-checkbox to material checkboxes
       var $input = $((selector) ? selector : this.options.togglebuttonElements)
         .filter(":notmdproc")
-        .data("mdproc", true)
-        .after("<span class='toggle'></span>");
+        .data("mdproc", true);
+      if ($input.siblings(".toggle").length == 0)
+        $input.after("<span class='toggle'></span>");
 
       _toggleTypeFocus($input);
     },
@@ -100,8 +102,9 @@
       // Add fake-radio to material radios
       var $input = $((selector) ? selector : this.options.radioElements)
         .filter(":notmdproc")
-        .data("mdproc", true)
-        .after("<span class='circle'></span><span class='check'></span>");
+        .data("mdproc", true);
+      if ($input.siblings(".circle").length == 0)
+        $input.after("<span class='circle'></span><span class='check'></span>");
 
       _toggleTypeFocus($input);
     },
@@ -156,7 +159,8 @@
           }
 
           // Add at the end of the form-group
-          $formGroup.append("<span class='material-input'></span>");
+          if ($formGroup.siblings(".material-input").length == 0)
+            $formGroup.append("<span class='material-input'></span>");
 
           // Support for file input
           if ($formGroup.find("input[type=file]").length > 0) {


### PR DESCRIPTION
(on a ruby on rails application with turbolinks)
When I press browser back and forward, the initialization code runs again creating double elements
