### PR TITLE
fixes #912: better styling for active buttons in input groups

### DIFF
--- a/less/_buttons.less
+++ b/less/_buttons.less
@@ -53,6 +53,10 @@
         }
       }
     }
+
+    &.active {
+      color: @mdb-text-color-light;
+    }
   }
 
   //--


### PR DESCRIPTION
Bootstrap uses `#fff` color for active buttons in input groups. Though here white color merges a bit into background on hover state

http://codepen.io/transGLUKator/pen/aNBJoz

Still it's a better experience than before.

fixes #912
