### PR TITLE
Removed color from label.control-label in label-size-variant

### DIFF
--- a/less/_inputs.less
+++ b/less/_inputs.less
@@ -44,7 +44,6 @@
   label.control-label {
     font-size: @static-font-size;
     line-height: @static-line-height;
-    color: @mdb-input-placeholder-color;
     font-weight: 400;
     margin: 16px 0 0 0; // std and lg
   }


### PR DESCRIPTION
Fixes #935 
The default label style already includes the base text color.
Setting it additionally in label-size-variant prevents the has-\* status variants from applying the proper text color.
