### PR TITLE
Made Bootstrap elements link full width

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
       <ul>
         <li class="active withripple" data-target="#about">Material Design for Bootstrap</li>
         <li class="withripple" data-target="#getting-started">Getting Started</li>
-        <li><a href="bootstrap-elements.html" target="_blank">Bootstrap elements <i class="mdi-action-open-in-new"></i></a>
+        <li><a href="bootstrap-elements.html" target="_blank" style="display: inline-block;width: 100%;">Bootstrap elements <i class="mdi-action-open-in-new"></i></a>
         </li>
         <li class="withripple" data-target="#checkbox">Checkbox</li>
         <li class="withripple" data-target="#radio-button">Radio Button</li>


### PR DESCRIPTION
This was more of annoying bug I noticed. 
The link for the bootstrap element was spanning the full width of the list item.

This fixes it, any suggestions would be great :)
