### PR TITLE
Fixed label padding - upstream bootstrap v3 will not be fixed.

### DIFF
--- a/less/_inputs.less
+++ b/less/_inputs.less
@@ -4,7 +4,7 @@
 .label {
   border-radius: @border-radius-small;
   .variations(~".label", ~"", background-color, @grey);
-  padding: .3em .6em;
+  padding: .3em .6em; // Make top & bottom .label padding the same: https://github.com/twbs/bootstrap/pull/19631
 }
 
 // must be broken out for reuse - webkit selector breaks firefox

--- a/less/_inputs.less
+++ b/less/_inputs.less
@@ -4,6 +4,7 @@
 .label {
   border-radius: @border-radius-small;
   .variations(~".label", ~"", background-color, @grey);
+  padding: .3em .6em .2em;
 }
 
 // must be broken out for reuse - webkit selector breaks firefox
@@ -347,4 +348,3 @@ select.form-control {
   height: 100%;
   z-index: 100;
 }
-

--- a/less/_inputs.less
+++ b/less/_inputs.less
@@ -4,7 +4,7 @@
 .label {
   border-radius: @border-radius-small;
   .variations(~".label", ~"", background-color, @grey);
-  padding: .3em .6em .2em;
+  padding: .3em .6em;
 }
 
 // must be broken out for reuse - webkit selector breaks firefox


### PR DESCRIPTION
Use to look like this:
![a](https://cloud.githubusercontent.com/assets/9902336/14061189/800cff6e-f37a-11e5-9e47-f24dc7521ce0.PNG)

Now looks like this:
![b](https://cloud.githubusercontent.com/assets/9902336/14061190/81bce9c8-f37a-11e5-9bcb-2aeb457baf2c.PNG)
