### PR TITLE
Improving dropdown style inside collapsible navbar

### DIFF
--- a/less/_navbar.less
+++ b/less/_navbar.less
@@ -94,37 +94,59 @@
       }
 
       // Dropdowns get custom display
-      .open .dropdown-menu {
-        > .dropdown-header {
-          border: 0;
-          color: inherit;
-        }
-        .divider {
-          border-bottom: 1px solid;
-          opacity: 0.08;
-        }
-        > li > a {
-          color: inherit;
-          &:hover,
-          &:focus {
-            color: inherit;
-            background-color: transparent;
+      .dropdown{
+        .dropdown-toggle{
+          .caret{
+            display:none;
+          }
+          &:after{
+            content: 'keyboard_arrow_right';
+            font-family: 'Material Icons';
+            font-size: 1.5em;
+            float:right;
           }
         }
-        > .active > a {
-          &,
-          &:hover,
-          &:focus {
-            color: inherit;
-            background-color: transparent;
-          }
+        .dropdown-menu{
+          margin-left:20px;
         }
-        > .disabled > a {
-          &,
-          &:hover,
-          &:focus {
-            color: inherit;
-            background-color: transparent;
+        &.open{
+          .dropdown-toggle:after{
+            content: 'keyboard_arrow_down';
+          }
+          .dropdown-menu {
+            > .dropdown-header {
+              border: 0;
+              color: inherit;
+            }
+            .divider {
+              border-bottom: 1px solid;
+              opacity: 0.08;
+            }
+            > li > a {
+              color: inherit;
+              font-size: inherit;
+              &:hover,
+              &:focus {
+                color: inherit;
+                background-color: transparent;
+              }
+            }
+            > .active > a {
+              &,
+              &:hover,
+              &:focus {
+                color: inherit;
+                background-color: transparent;
+              }
+            }
+            > .disabled > a {
+              &,
+              &:hover,
+              &:focus {
+                color: inherit;
+                background-color: transparent;
+              }
+            }
           }
         }
       }
@@ -197,6 +219,11 @@
     }
     .dropdown-menu {
       border-radius: @border-radius-base;
+      @media (max-width: @grid-float-breakpoint-max) {
+        .dropdown-header{
+          background-color: lighten(@variation-color,5%);
+        }
+      }
       li > a {
         font-size: @mdb-dropdown-font-size;
         padding: 13px 16px;


### PR DESCRIPTION
 This PR improves the style of dropdown inside collapsible navbar so that it looks like an actual submenu.

Screenshots for comparison:

| Before | After |
| :-: | :-: |
| ![dropdown_before](https://cloud.githubusercontent.com/assets/6869601/15805180/be5aeedc-2b3f-11e6-85db-3735c697b231.PNG) | ![dropdown_after](https://cloud.githubusercontent.com/assets/6869601/15805181/be5bb6dc-2b3f-11e6-8880-40fb94eb8f86.PNG) |

**Changes:**
- Default caret icon changes to material design keyboard arrow icons (added via `:after` pseudo element) depending on dropdown's state
- Dropdown menu gets a little padding to indicate it's a submenu
- Dropdown headers get's a ligher background to easily distinguish from it's sub items.
- Dropdown item's `font-size` is reset to `inherit` so that they aren't bigger than parent menu items which looks odd.

Testcase: [codepen](http://codepen.io/anon/pen/OXVazp): 
