### PR TITLE
navbar material icons fix for IE

### DIFF
--- a/less/_navbar.less
+++ b/less/_navbar.less
@@ -104,6 +104,7 @@
             font-family: 'Material Icons';
             font-size: 1.5em;
             float:right;
+            font-feature-settings: 'liga'; /* Support for IE. */
           }
         }
         .dropdown-menu{


### PR DESCRIPTION
Navbar material icon font fix for IE mobile and edge. Please see https://github.com/google/material-design-icons/issues/179 for more info.
