### PR TITLE
.list-group.list-group-no-icon

### DIFF
--- a/bootstrap-elements.html
+++ b/bootstrap-elements.html
@@ -534,7 +534,7 @@
             <a href="javascript:void(0)" class="btn btn-raised btn-link">Link</a>
           </p>
         </fieldset>
-        
+
         <h3>Button sizes</h3>
 
         <p class="bs-component">
@@ -658,9 +658,9 @@
             </div>
           </div>
         </div>
-        
-        
-        
+
+
+
         <h3><small><code>btn-lg.btn-block.btn-raised</code></small></h3>
         <div class="bs-component">
           <a href="javascript:void(0)" class="btn btn-default btn-lg btn-block btn-raised">Block level button</a>
@@ -732,7 +732,7 @@
           </div>
         </div>
 
-        
+
       </div>
     </div>
   </div>
@@ -1593,10 +1593,10 @@
                 <i class="material-icons">folder</i>
               </div>
               <div class="row-content">
-                <div class="least-content">8m</div>
-                <h4 class="list-group-item-heading">Tile with a label</h4>
+                <div class="action-secondary"><i class="material-icons">info</i></div>
+                <h4 class="list-group-item-heading">Tile with an icon</h4>
 
-                <p class="list-group-item-text">Maecenas sed diam eget risus varius blandit.</p>
+                <p class="list-group-item-text">Donec id elit non mi porta gravida at eget metus.</p>
               </div>
             </div>
             <div class="list-group-separator"></div>
@@ -1605,40 +1605,31 @@
       </div>
       <div class="col-md-4">
         <div class="bs-component">
-          <div class="list-group">
+          <div class="list-group list-group-no-icon">
             <div class="list-group-item">
-              <div class="row-action-primary">
-                <i class="material-icons">folder</i>
-              </div>
               <div class="row-content">
                 <div class="action-secondary"><i class="material-icons">info</i></div>
                 <h4 class="list-group-item-heading">Tile with an icon</h4>
 
-                <p class="list-group-item-text">Donec id elit non mi porta gravida at eget metus.</p>
+                <p class="list-group-item-text">And <b>without avatar</b> on left.</p>
               </div>
             </div>
             <div class="list-group-separator"></div>
             <div class="list-group-item">
-              <div class="row-action-primary">
-                <i class="material-icons">folder</i>
-              </div>
               <div class="row-content">
                 <div class="action-secondary"><i class="material-icons">info</i></div>
                 <h4 class="list-group-item-heading">Tile with an icon</h4>
 
-                <p class="list-group-item-text">Maecenas sed diam eget risus varius blandit.</p>
+                <p class="list-group-item-text">And <b>without avatar</b> on left.</p>
               </div>
             </div>
             <div class="list-group-separator"></div>
             <div class="list-group-item">
-              <div class="row-action-primary">
-                <i class="material-icons">folder</i>
-              </div>
               <div class="row-content">
                 <div class="action-secondary"><i class="material-icons">info</i></div>
                 <h4 class="list-group-item-heading">Tile with an icon</h4>
 
-                <p class="list-group-item-text">Maecenas sed diam eget risus varius blandit.</p>
+                <p class="list-group-item-text">And <b>without avatar</b> on left.</p>
               </div>
             </div>
             <div class="list-group-separator"></div>

--- a/less/_lists.less
+++ b/less/_lists.less
@@ -99,4 +99,14 @@
       float: right;
     }
   }
+  &.list-group-no-icon {
+    .list-group-item .row-content {
+      width: 100%;
+    }
+    .list-group-separator {
+      &:before {
+        width: 100%;
+      }
+    }
+  }
 }


### PR DESCRIPTION
Allows to remove icon and use all the width of the list group.

When removing icon or avatar in list groups, there is still an unused space on right, and separator is shifted and don't take the full width.

This PR introduce the class `.list-group-no-icon` to add to the list group:

``` html
<div class="list-group list-group-no-icon">
      <div class="list-group-item">
        <div class="row-content">
          <p class="list-group-item-text">content...</p>
        </div>
      </div>
      <div class="list-group-separator"></div>
```

See example without this class (makes superfluous padding), and with this class (use the width):

http://codepen.io/Alcalyn/pen/vKrmXw

Also edited exemple page to show a list group without avatar.
