### PR TITLE
Add Eyeglass compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   },
   "eyeglass": {
     "exports": false,
-    "needs": "^1.2.1",
+    "needs": "*",
     "sassDir": "sass"
   },
   "_bootstraps_dependencies_we_dont_use_yet": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "jquery": ">=1.9.1"
   },
   "devDependencies": {
-    "eyeglass": "^1.2.1",
     "grunt": "^0.4.5",
     "grunt-autoprefixer": "~3.0.3",
     "grunt-bootlint": "latest",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "google",
     "android",
     "browser",
-    "framework"
+    "framework",
+    "eyeglass-module"
   ],
   "homepage": "https://github.com/FezVrasta/bootstrap-material-design",
   "dependencies": {
@@ -31,8 +32,10 @@
     "jquery": ">=1.9.1"
   },
   "devDependencies": {
+    "eyeglass": "^1.2.1",
     "grunt": "^0.4.5",
     "grunt-autoprefixer": "~3.0.3",
+    "grunt-bootlint": "latest",
     "grunt-contrib-clean": "~0.6.0",
     "grunt-contrib-compress": "~0.14.0",
     "grunt-contrib-concat": "~0.5.1",
@@ -40,24 +43,28 @@
     "grunt-contrib-copy": "~0.8.0",
     "grunt-contrib-csslint": "~0.5.0",
     "grunt-contrib-cssmin": "~0.14.0",
-    "grunt-contrib-jshint": "~0.11.2",
     "grunt-contrib-htmlmin": "~0.6.0",
+    "grunt-contrib-jasmine": "^0.8.0",
+    "grunt-contrib-jshint": "~0.11.2",
     "grunt-contrib-less": "~1.1.0",
+    "grunt-contrib-sass": "^0.8.1",
     "grunt-contrib-uglify": "~0.9.2",
     "grunt-contrib-watch": "~0.6.1",
+    "grunt-dependency-installer": "^0.2.0",
     "grunt-exec": "~0.4.6",
     "grunt-html": "~5.0.1",
     "grunt-jekyll": "~0.4.2",
     "grunt-jscs": "~2.3.0",
-    "grunt-bootlint": "latest",
-    "grunt-contrib-jasmine": "^0.8.0",
-    "grunt-dependency-installer": "^0.2.0",
     "grunt-less-to-sass": "latest",
     "grunt-newer": "^0.7.0",
-    "grunt-contrib-sass": "^0.8.1",
     "jshint-stylish": "^1.0.0",
     "load-grunt-tasks": "~3.3.0",
     "spacejam": "^1.1.1"
+  },
+  "eyeglass": {
+    "exports": false,
+    "needs": "^1.2.1",
+    "sassDir": "sass"
   },
   "_bootstraps_dependencies_we_dont_use_yet": {
     "grunt-contrib-jade": "~0.15.0",
@@ -69,5 +76,3 @@
     "time-grunt": "^1.2.1"
   }
 }
-
-


### PR DESCRIPTION
[Eyeglass](https://github.com/sass-eyeglass/eyeglass) is an extension that lets you import SASS projects easily into your own SASS or SCSS files.

With the handful of additions I've made to your repo's `package.json`, and no new dependencies, Eyeglass would make it possible to do the following in a project that implements bootstrap-material-design (and has it installed via NPM):

-   Run `npm install --save-dev eyeglass`
-   Add the Eyeglass processor to the project's build system (our projects use Gulp, so basically all we do is wrap our existing `gulp-sass` call in an `eyeglass()` function, more info [here](https://github.com/sass-eyeglass/eyeglass/blob/master/site-src/docs/integrations/gulp.md))
-   Import bootstrap-material design into your own project with the following line in a project SCSS file (or a similar line in a SASS file):

```scss
@import 'bootstrap-material-design/desired_file'
```

where the first part of that import is this theme's NPM-installable name, and the second part is an SCSS file in this repo's `./sass/` folder.

Eyeglass is being used by a growing number of projects (including the official [bootstrap-sass](https://github.com/twbs/bootstrap-sass) port), and adding these few lines to your theme's `package.json` would make installing into projects even easier.

Please let me know if you have any questions. Thanks for your work on this theme!