### PR TITLE
fix: import transitions in _core-bootstrap. Fixes #1210

### DIFF
--- a/scss/_core-bootstrap.scss
+++ b/scss/_core-bootstrap.scss
@@ -36,6 +36,7 @@
 @import "bootstrap/scss/tables";
 @import "bootstrap/scss/forms";
 @import "bootstrap/scss/buttons";
+@import "bootstrap/scss/transitions";
 
 // Components
 @import "bootstrap/scss/dropdown";


### PR DESCRIPTION
Currently anything that uses .collapse doesn't work because _transitions.scss is missing in _core-bootstrap.scss. This patch fixes that.

Non-working example on the Documentation itself: https://fezvrasta.github.io/bootstrap-material-design/docs/4.0/components/collapse/ (collapsed content is show by default, clicking the buttons has no effect)

Wouldn't it be easier to just `@import "bootstrap/scss/bootstrap"` instead of having a (mostly duplicate) _core-bootstrap.scss in there? Seems to be working fine with node-sass even it's not underscored (I'm new to sass, so maybe I'm missing something)