### PR TITLE
Update to install the correct version

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Major differences:
 
 You may install this theme using NPM or Bower:
 
-- NPM : `npm install bootstrap-material-design`
+- NPM : `npm install bootstrap-material-design@0.5.10`
 - Bower : `bower install bootstrap-material-design`
 
 If you prefer, you can include this framework in your project using our official CDN:


### PR DESCRIPTION
When I execute ```npm install bootstrap-material-design``` without especifying the version, the last version is installed, for bootstrap 4. I added the last v3 version to the command