### PR TITLE
error occured when building with webpack (mix)

### DIFF
--- a/js/bootstrapMaterialDesign.js
+++ b/js/bootstrapMaterialDesign.js
@@ -1,5 +1,5 @@
 /* globals Popper */
-Popper.Defaults.modifiers.computeStyle.gpuAcceleration = false
+Popper.default.Defaults.modifiers.computeStyle.gpuAcceleration = false
 
 /**
  * $.bootstrapMaterialDesign(config) is a macro class to configure the components generally


### PR DESCRIPTION
* build process with webpack + mix (laravel)
* built bundel threw error in browser due to wrong access to default

![image](https://user-images.githubusercontent.com/1303151/35865378-a01e9238-0b54-11e8-866e-d400a93556dd.png)

default webpack.config.js
```
let mix = require('laravel-mix')
mix.js('resources/assets/js/init.js', 'public/js')
```
init.js
```
import 'bootstrap'
import 'bootstrap-material-design'
```
included via default js script tag

I've changed the specific line in the already compiled version of the script in the dist folder and it worked afterwards. I think the main problem here is the access via the global Popper object, all the other usages of popper are done via the new Popper() object, which is structured differently (default is not present there, webpack-magic ;-) ). Should not have any impact on the other calls.