### PR TITLE
fixed continuous on change trigger for date inputs

### DIFF
--- a/js/autofill.js
+++ b/js/autofill.js
@@ -61,7 +61,7 @@ const Autofill = ($ => {
           let $inputs = $(event.currentTarget)
             .closest("form")
             .find("input")
-            .not("[type=file]");
+            .not("[type=file], [type=date]");
           focused = setInterval(() => {
             $inputs.each((index, element) => {
               let $element = $(element);


### PR DESCRIPTION
$element.val() !== $element.attr("value") are never be the same on inputs with type date. Value will be just empty.