### PR TITLE
Fix infinite "change" event triggering loop

### DIFF
--- a/js/autofill.js
+++ b/js/autofill.js
@@ -45,7 +45,13 @@ const Autofill = ($ => {
       setInterval(() => {
         $("input[type!=checkbox]").each((index, element) => {
           let $element = $(element);
-          if ($element.val() && $element.val() !== $element.attr("value")) {
+
+          let initialValue = $element.attr("value");
+          if (initialValue === undefined) {
+            initialValue = "";
+          }
+
+          if ($element.val() && $element.val() !== initialValue) {
             $element.trigger("change");
           }
         });
@@ -65,7 +71,13 @@ const Autofill = ($ => {
           focused = setInterval(() => {
             $inputs.each((index, element) => {
               let $element = $(element);
-              if ($element.val() !== $element.attr("value")) {
+
+              let initialValue = $element.attr("value");
+              if (initialValue === undefined) {
+                initialValue = "";
+              }
+
+              if ($element.val() !== initialValue) {
                 $element.trigger("change");
               }
             });


### PR DESCRIPTION
This fixes a bug which creates infinite loops of `change` events for inputs that don't have a `value` attribute.

The jQuery `.val()` function always returns an empty string when the input has no `value` attribute whereas the `.attr('value')` function returns `undefined`. In such case, the input was considered changed and an event was triggered.

Unfortunately I wasn't able to create a Codepen that demonstrates the issue and I don't have much time to try harder.