### PR TITLE
Changed recommended CSS to not include invalid chars

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,7 +61,7 @@ gem install bootstrap-material-design -v 4.1.1
 
 <h5>CSS only</h5>
 {% highlight html %}
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700|Material+Icons">
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700%7CMaterial+Icons">
 <link rel="stylesheet" href="{{ site.cdn.css }}" integrity="{{ site.cdn.css_hash }}" crossorigin="anonymous">
 {% endhighlight %}
 


### PR DESCRIPTION
According to https://stackoverflow.com/questions/1547899/which-characters-make-a-url-invalid/1547940#1547940
and using https://validator.w3.org/nu/ . The char '|' is an invalid character for href links.

I have changed it to one which seems to work equivalently.