### PR TITLE
Fix input type DATE bug, for issue #1377

### DIFF
--- a/docs/4.0/material-design/forms.md
+++ b/docs/4.0/material-design/forms.md
@@ -44,7 +44,7 @@ Form controls flavored by Material Design for Bootstrap customizations such as `
     </select>
   </div>
   <div class="form-group">
-    <label for="exampleFormControlDateType1">Example date</label>
+    <label for="exampleFormControlDateType1" class="bmd-label-floating">Example date</label>
     <input type="date" class="form-control" id="exampleFormControlDateType1">
   </div>
   <div class="form-group">

--- a/docs/4.0/material-design/forms.md
+++ b/docs/4.0/material-design/forms.md
@@ -44,6 +44,10 @@ Form controls flavored by Material Design for Bootstrap customizations such as `
     </select>
   </div>
   <div class="form-group">
+    <label for="exampleFormControlDateType1">Example date</label>
+    <input type="date" class="form-control" id="exampleFormControlDateType1">
+  </div>
+  <div class="form-group">
     <label for="exampleTextarea" class="bmd-label-floating">Example textarea</label>
     <textarea class="form-control" id="exampleTextarea" rows="3"></textarea>
   </div>

--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -227,3 +227,18 @@ select {
     }
   }
 }
+
+// Fix input type data
+// Type text overwriting label-floating, making it's layout incorrect
+input[type="date"]::-webkit-datetime-edit {
+  color: transparent;
+}
+input[type="date"]:focus::-webkit-datetime-edit {
+  color: black !important;
+}
+.is-filled {
+  input[type="date"]::-webkit-datetime-edit {
+    color: black !important;
+  }
+}
+//-------------------------------------------------------------------


### PR DESCRIPTION
Input type text overwrites label text, making incorrect layout.
Add input type **DATE** to docs.
It will take care of **[issue#1377](https://github.com/FezVrasta/bootstrap-material-design/issues/1377)**.