### PR TITLE
Patch for allowing theme overrides

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -29,7 +29,7 @@ $theme-colors: map-merge((
   danger: $red,
   light: $grey-100,
   dark: $grey-800
-), $theme-colors);
+), $theme-colors) !default;
 
 // Customized BS variables
 @import "variables/bootstrap/components";


### PR DESCRIPTION
Without the `!default` declaration here, I can't override the theme-colors map making it impossible to change the colors used in my custom theme. This allows for that to work.