### PR TITLE
Reverting commit 435bc59 which breaks theme-colors

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -29,7 +29,7 @@ $theme-colors: map-merge((
   danger: $red,
   light: $grey-100,
   dark: $grey-800
-), $theme-colors) !default;
+), $theme-colors);
 
 // Customized BS variables
 @import "variables/bootstrap/components";

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -22,14 +22,23 @@ $bmd-label-color-inner-focus: $gray !default; // e.g. radio label or text-muted 
 // Bootstrap Material Design default colors (these can be override by user)
 $theme-colors: () !default;
 $theme-colors: map-merge((
-  primary: $teal,
-  success: $green,
-  info: $light-blue,
-  warning: $deep-orange,
-  danger: $red,
-  light: $grey-100,
-  dark: $grey-800
+    "primary":    $teal,
+    "secondary":  $deep-purple-300,
+    "success":    $green,
+    "info":       $light-blue,
+    "warning":    $deep-orange,
+    "danger":     $red,
+    "light":      $grey-100,
+    "dark":       $grey-800
 ), $theme-colors);
+
+$theme-colors: map-merge(
+  (
+
+  ),
+  $theme-colors
+);
+
 
 // Customized BS variables
 @import "variables/bootstrap/components";


### PR DESCRIPTION
Revert commit [435bc59](https://github.com/FezVrasta/bootstrap-material-design/commit/435bc59a540c78eafb59ed75413f604f61df39e1) which  is breaking theme-colors override. Cuz of this bootstrap's colors are being used instead of BMD's.
node.js => 10.21.0
gulp=> cli 2.3.0 local 4.0.2
gulp-sass => 4.1.0
bootstrap=>4.5.0