### PR TITLE
added closing tag in docs navbar.md input field

### DIFF
--- a/docs/4.0/bootstrap-components/navbar.md
+++ b/docs/4.0/bootstrap-components/navbar.md
@@ -63,7 +63,7 @@ Here's an example of all the sub-components included in a responsive light-theme
       </li>
     </ul>
     <form class="form-inline my-2 my-lg-0">
-      <input class="form-control mr-sm-2" type="search" placeholder="Search" aria-label="Search">
+      <input class="form-control mr-sm-2" type="search" placeholder="Search" aria-label="Search" />
       <button class="btn btn-outline-success my-2 my-sm-0" type="submit">Search</button>
     </form>
   </div>


### PR DESCRIPTION
In Docs Navbar.md had missing a closing tag in input tag (first navbar code). Which causes unable to compile in React apps.

![image](https://user-images.githubusercontent.com/45540333/94615287-556fbb80-02c9-11eb-98b7-48a866c0af03.png)
