### PR TITLE
Rename deprecated color-adjust property to print-color-adjust

### DIFF
--- a/src/scss/bootstrap-rtl-fix/forms/_form-check.scss
+++ b/src/scss/bootstrap-rtl-fix/forms/_form-check.scss
@@ -25,7 +25,7 @@
   background-size: contain;
   border: $form-check-input-border;
   appearance: none;
-  color-adjust: exact; // Keep themed appearance for print
+  print-color-adjust: exact; // Keep themed appearance for print
   @include transition($form-check-transition);
 
   &[type='checkbox'] {

--- a/src/scss/bootstrap/forms/_form-check.scss
+++ b/src/scss/bootstrap/forms/_form-check.scss
@@ -25,7 +25,7 @@
   background-size: contain;
   border: $form-check-input-border;
   appearance: none;
-  color-adjust: exact; // Keep themed appearance for print
+  print-color-adjust: exact; // Keep themed appearance for print
   @include transition($form-check-transition);
 
   &[type='checkbox'] {


### PR DESCRIPTION
As per the latest [CSS Color Adjustment Module Level 1 specification](https://www.w3.org/TR/css-color-adjust-1/), the `color-adjust` property has been deprecated. In its place is the property `print-color-adjust`.  As you can see [in version 10.4.6 of Autoprefixer](https://github.com/postcss/autoprefixer/commit/51b991c6175fe5e0f90e20041e10441df1434670), a deprecation warning was added.

Currently, for anyone using Autoprefixer 10.4.6 onwards with MDB UI Kit, this library will break their builds with the warning unless they suppress them.

Bootstrap implemented the same change in version 5.2 of Bootstrap [here](https://github.com/twbs/bootstrap/commit/f82b2ba20d50d49a1554f4fa2891e3e65760fa98).

The fix is to rename the `color-adjust` property to `print-color-adjust`, and the warning goes away.