### PR TITLE
Fixed libsass (python) inclusion errors

### DIFF
--- a/src/scss/free/_variables.scss
+++ b/src/scss/free/_variables.scss
@@ -707,12 +707,12 @@ $border-radius-lg: 0.5rem !default;
 // scss-docs-start box-shadow-variables
 $box-shadow-0: none !default;
 
-$box-shadow-1: 0 0px 2px 0 rgb(0 0 0 / 7%), 0 1px 1px 0 rgb(0 0 0 / 4%) !default;
-$box-shadow-2: 0 0px 3px 0 rgb(0 0 0 / 7%), 0 2px 2px 0 rgb(0 0 0 / 4%) !default;
-$box-shadow-3: 0 2px 6px -1px rgb(0 0 0 / 7%), 0 6px 18px -1px rgb(0 0 0 / 4%) !default;
-$box-shadow-4: 0 2px 15px -3px rgb(0 0 0 / 7%), 0 10px 20px -2px rgb(0 0 0 / 4%) !default;
-$box-shadow-5: 0 2px 25px -5px rgb(0 0 0 / 7%), 0 25px 21px -5px rgb(0 0 0 / 4%) !default;
-$box-shadow-6: 0 2px 35px -12px rgb(0 0 0 / 21%), 0 50px 40px -5px rgb(0 0 0 / 4%) !default;
+$box-shadow-1: 0 0px 2px 0 rgba(0, 0, 0, 0.07), 0 1px 1px 0 rgba(0, 0, 0, 0.04) !default;
+$box-shadow-2: 0 0px 3px 0 rgba(0, 0, 0, 0.07), 0 2px 2px 0 rgba(0, 0, 0, 0.04) !default;
+$box-shadow-3: 0 2px 6px -1px rgba(0, 0, 0, 0.07), 0 6px 18px -1px rgba(0, 0, 0, 0.04) !default;
+$box-shadow-4: 0 2px 15px -3px rgba(0, 0, 0, 0.07), 0 10px 20px -2px rgba(0, 0, 0, 0.04) !default;
+$box-shadow-5: 0 2px 25px -5px rgba(0, 0, 0, 0.07), 0 25px 21px -5px rgba(0, 0, 0, 0.04) !default;
+$box-shadow-6: 0 2px 35px -12px rgba(0, 0, 0, 0.21), 0 50px 40px -5px rgba(0, 0, 0, 0.04) !default;
 
 $box-shadow-1-soft: 0 1px 5px 0 rgba(0, 0, 0, 0.05) !default;
 $box-shadow-2-soft: 0 2px 10px 0 rgba(0, 0, 0, 0.05) !default;
@@ -721,12 +721,12 @@ $box-shadow-4-soft: 0 10px 20px 0 rgba(0, 0, 0, 0.05) !default;
 $box-shadow-5-soft: 0 15px 30px 0 rgba(0, 0, 0, 0.05) !default;
 $box-shadow-6-soft: 0 20px 40px 0 rgba(0, 0, 0, 0.05) !default;
 
-$box-shadow-1-strong: 0 0px 2px 0 rgb(0 0 0 / 16%), 0 1px 1px 0 rgb(0 0 0 / 10%) !default;
-$box-shadow-2-strong: 0 0px 3px 0 rgb(0 0 0 / 16%), 0 2px 2px 0 rgb(0 0 0 / 10%) !default;
-$box-shadow-3-strong: 0 2px 6px -1px rgb(0 0 0 / 16%), 0 6px 18px -1px rgb(0 0 0 / 10%) !default;
-$box-shadow-4-strong: 0 2px 15px -3px rgb(0 0 0 / 16%), 0 10px 20px -2px rgb(0 0 0 / 10%) !default;
-$box-shadow-5-strong: 0 2px 25px -5px rgb(0 0 0 / 16%), 0 25px 21px -5px rgb(0 0 0 / 10%) !default;
-$box-shadow-6-strong: 0 2px 35px -12px rgb(0 0 0 / 26%), 0 50px 40px -5px rgb(0 0 0 / 10%) !default;
+$box-shadow-1-strong: 0 0px 2px 0 rgba(0, 0, 0, 0.16), 0 1px 1px 0 rgba(0, 0, 0, 0.10) !default;
+$box-shadow-2-strong: 0 0px 3px 0 rgba(0, 0, 0, 0.16), 0 2px 2px 0 rgba(0, 0, 0, 0.10) !default;
+$box-shadow-3-strong: 0 2px 6px -1px rgba(0, 0, 0, 0.16), 0 6px 18px -1px rgba(0, 0, 0, 0.10) !default;
+$box-shadow-4-strong: 0 2px 15px -3px rgba(0, 0, 0, 0.16), 0 10px 20px -2px rgba(0, 0, 0, 0.10) !default;
+$box-shadow-5-strong: 0 2px 25px -5px rgba(0, 0, 0, 0.16), 0 25px 21px -5px rgba(0, 0, 0, 0.10) !default;
+$box-shadow-6-strong: 0 2px 35px -12px rgba(0, 0, 0, 0.26), 0 50px 40px -5px rgba(0, 0, 0, 0.10) !default;
 
 $box-shadow-3-top: 0 -10px 20px 0 rgba(0, 0, 0, 0.05) !default;
 $box-shadow-inner: inset 0 2px 4px 0 rgba(0, 0, 0, 0.06) !default;

--- a/src/scss/free/mixins/_buttons.scss
+++ b/src/scss/free/mixins/_buttons.scss
@@ -5,14 +5,14 @@
 
 // scss-docs-start btn-variant-mixin
 @mixin button-variant(
-  $background,
+  $background: transparent,
   $color: color-contrast($background),
-  $shadow,
-  $hover-background,
+  $shadow: none,
+  $hover-background: $background,
   $hover-color: color-contrast($hover-background),
-  $focus-background,
+  $focus-background: $background,
   $focus-color: color-contrast($focus-background),
-  $active-background,
+  $active-background: $background,
   $active-color: color-contrast($active-background)
 ) {
   --#{$prefix}btn-bg: #{$background};


### PR DESCRIPTION
Hi,

I am using mdb-ui-kit in a python project (django), and include directly the SASS layer from my main.scss.

As it turns, libsass doesn't like a few lines in the code, so I fixed it and would like to share the update for you.

Mainly:
- optionnal arguments must come after mandatory argument (fixed by providing reasonable defaults)
- `rgb` function doesn't like the `r g b / a` notation (fixed by using `rgba` instead)